### PR TITLE
fix: install dependencies in CI and add smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest ruff mypy
+          pip install -r requirements.txt
+          pip install ruff mypy
       - name: Run tests
         run: pytest -q
       - name: Lint

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This seed repository uses a minimal continuous integration pipeline. All pull re
 Run these commands locally before pushing changes:
 
 ```sh
-pip install pytest ruff mypy
+pip install -r requirements.txt ruff mypy
 ruff check .
 mypy .
 pytest -q

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,0 +1,6 @@
+"""Basic smoke test to ensure required dependencies are present."""
+
+
+def test_websockets_importable() -> None:
+    """`websockets` should be importable once installed via requirements."""
+    import websockets  # noqa: F401


### PR DESCRIPTION
## Summary
- install project requirements before running checks
- add a smoke test ensuring `websockets` dependency is present
- document dependency installation in contributing guide

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24bbe4d288333a4fe99b5b638e955