### PR TITLE
feat: add minimal console client

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ python -m server.net
 
 The server listens on `ws://127.0.0.1:7777/ws` and broadcasts an empty snapshot every second.
 
+Start the console client in another terminal:
+
+```sh
+python -m client.net
+```
+
+The client connects, prints the welcome message, then shows each snapshot tick with a running messages-per-second rate.
+
 ## Contributing
 
 This seed repository uses a minimal continuous integration pipeline. All pull requests run:

--- a/client/net.py
+++ b/client/net.py
@@ -1,1 +1,70 @@
-"""Networking for the client."""
+"""Minimal console client networking."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Dict
+
+import websockets  # type: ignore[import-not-found]
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_hello(seq: str = "1") -> Dict[str, Any]:
+    """Return a hello message following :mod:`PROTOCOL`.
+
+    Parameters
+    ----------
+    seq:
+        Sequence identifier for the message.
+    """
+
+    return {
+        "t": "hello",
+        "seq": seq,
+        "ts": int(time.time() * 1000),
+        "accept_major": [1],
+        "min_minor": 0,
+        "id_type": "string",
+        "accept_features": [],
+        "want_fields": ["node.p", "edge.q"],
+        "client_version": "0.1.0",
+    }
+
+
+async def main() -> None:
+    """Connect to the server and print snapshot information."""
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    uri = "ws://127.0.0.1:7777/ws"
+    hello = build_hello()
+    async with websockets.connect(uri) as ws:  # type: ignore[arg-type]
+        await ws.send(json.dumps(hello))
+        welcome = json.loads(await ws.recv())
+        print(welcome)
+
+        start = time.monotonic()
+        count = 0
+        async for raw in ws:
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:  # pragma: no cover - ignore bad messages
+                continue
+            if msg.get("t") != "snapshot":
+                continue
+            count += 1
+            elapsed = time.monotonic() - start
+            rate = count / elapsed if elapsed else 0.0
+            tick = msg.get("tick")
+            print(f"tick={tick} rate={rate:.1f} msg/s")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/tests/test_client_net.py
+++ b/tests/test_client_net.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from client import net
+
+
+def test_build_hello(monkeypatch) -> None:
+    monkeypatch.setattr(net.time, "time", lambda: 0)
+    msg = net.build_hello("7")
+    assert msg == {
+        "t": "hello",
+        "seq": "7",
+        "ts": 0,
+        "accept_major": [1],
+        "min_minor": 0,
+        "id_type": "string",
+        "accept_features": [],
+        "want_fields": ["node.p", "edge.q"],
+        "client_version": "0.1.0",
+    }
+

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -3,4 +3,4 @@
 
 def test_websockets_importable() -> None:
     """`websockets` should be importable once installed via requirements."""
-    import websockets  # noqa: F401
+    import websockets  # type: ignore[import-not-found]  # noqa: F401


### PR DESCRIPTION
## Summary
- implement minimal console client that sends hello, prints welcome, and outputs snapshot tick rates
- document client usage
- cover hello message construction with unit test

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

## Assumptions
- hello messages include `t`, `seq`, and `ts` fields in addition to parameters described in the protocol


------
https://chatgpt.com/codex/tasks/task_e_68b24ddd1a90833392ee7c520d578c0c