### PR TITLE
feat: console build commands and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ client/
     state.py
 ```
 
+## Quick Start
+
+```sh
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python -m server.net &
+python -m client.net
+# then in the client:
+add_node n1 source
+add_node n2 sink
+add_pipe e1 n1 n2
+set_param n1 target_pressure 101325
+pause
+resume
+rate 40
+save
+```
+
+The server writes `save-*.json` in its working directory.
+
+### Troubleshooting
+
+- Close other apps using port 7777.
+- Requires Python 3.10+.
+- Firewalls may block localhost WebSocket traffic.
+- Stop the server with Ctrl+C.
+
 ## Running
 
 ```sh

--- a/client/net.py
+++ b/client/net.py
@@ -1,32 +1,54 @@
-"""Minimal console client networking."""
+"""Minimal console client with text commands."""
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+import sys
 import time
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Set
 
 import websockets  # type: ignore[import-not-found]
 
 
 logger = logging.getLogger(__name__)
 
+NODE_TYPES: Set[str] = {
+    "source",
+    "sink",
+    "junction",
+    "pump",
+    "valve",
+    "accumulator",
+}
+
+
+def _now_ms() -> int:
+    """Return current time in milliseconds."""
+    return int(time.time() * 1000)
+
+
+@dataclass
+class Seq:
+    """Sequence generator for `seq` fields."""
+
+    value: int = 0
+
+    def next(self) -> str:
+        self.value += 1
+        return str(self.value)
+
 
 def build_hello(seq: str = "1") -> Dict[str, Any]:
-    """Return a hello message following :mod:`PROTOCOL`.
-
-    Parameters
-    ----------
-    seq:
-        Sequence identifier for the message.
-    """
+    """Return a hello message following :mod:`PROTOCOL`."""
 
     return {
         "t": "hello",
         "seq": seq,
-        "ts": int(time.time() * 1000),
+        "ts": _now_ms(),
         "accept_major": [1],
         "min_minor": 0,
         "id_type": "string",
@@ -36,33 +58,117 @@ def build_hello(seq: str = "1") -> Dict[str, Any]:
     }
 
 
-async def main() -> None:
-    """Connect to the server and print snapshot information."""
+def parse_command(line: str, seq: Seq) -> Optional[Dict[str, Any]]:
+    """Parse a command line into a protocol message."""
 
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
-    )
-    uri = "ws://127.0.0.1:7777/ws"
-    hello = build_hello()
-    async with websockets.connect(uri) as ws:  # type: ignore[arg-type]
-        await ws.send(json.dumps(hello))
-        welcome = json.loads(await ws.recv())
-        print(welcome)
+    parts = line.strip().split()
+    if not parts:
+        return None
+    cmd = parts[0]
+    ts = _now_ms()
+    if cmd == "add_node" and len(parts) == 3 and parts[2] in NODE_TYPES:
+        edit = {
+            "op": "add_node",
+            "id": parts[1],
+            "type": parts[2],
+            "params": {},
+        }
+        return {"t": "edit_batch", "seq": seq.next(), "ts": ts, "edits": [edit]}
+    if cmd == "add_pipe" and len(parts) == 4:
+        edit = {
+            "op": "add_pipe",
+            "id": parts[1],
+            "a": parts[2],
+            "b": parts[3],
+            "params": {},
+        }
+        return {"t": "edit_batch", "seq": seq.next(), "ts": ts, "edits": [edit]}
+    if cmd == "set_param" and len(parts) >= 4:
+        value_str = " ".join(parts[3:])
+        try:
+            value = json.loads(value_str)
+        except json.JSONDecodeError:
+            value = value_str
+        edit = {
+            "op": "set_param",
+            "id": parts[1],
+            "key": parts[2],
+            "value": value,
+        }
+        return {"t": "edit_batch", "seq": seq.next(), "ts": ts, "edits": [edit]}
+    if cmd == "del" and len(parts) == 2:
+        edit = {"op": "del", "id": parts[1]}
+        return {"t": "edit_batch", "seq": seq.next(), "ts": ts, "edits": [edit]}
+    if cmd == "pause" and len(parts) == 1:
+        return {"t": "control", "seq": seq.next(), "ts": ts, "pause": True}
+    if cmd == "resume" and len(parts) == 1:
+        return {"t": "control", "seq": seq.next(), "ts": ts, "pause": False}
+    if cmd == "rate" and len(parts) == 2:
+        try:
+            hz = int(float(parts[1]))
+        except ValueError:
+            return None
+        return {"t": "control", "seq": seq.next(), "ts": ts, "tick_hz": hz}
+    if cmd == "save" and len(parts) == 1:
+        return {"t": "save", "seq": seq.next(), "ts": ts}
+    return None
 
-        start = time.monotonic()
-        count = 0
-        async for raw in ws:
-            try:
-                msg = json.loads(raw)
-            except json.JSONDecodeError:  # pragma: no cover - ignore bad messages
-                continue
-            if msg.get("t") != "snapshot":
-                continue
+
+async def _recv_loop(ws) -> None:
+    start = time.monotonic()
+    count = 0
+    async for raw in ws:
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:  # pragma: no cover - ignore bad messages
+            continue
+        t = msg.get("t")
+        if t == "snapshot":
             count += 1
             elapsed = time.monotonic() - start
             rate = count / elapsed if elapsed else 0.0
             tick = msg.get("tick")
             print(f"tick={tick} rate={rate:.1f} msg/s")
+        elif t == "error":
+            print(json.dumps(msg))
+
+
+async def _input_loop(ws, seq: Seq) -> None:
+    loop = asyncio.get_running_loop()
+    while True:
+        line = await loop.run_in_executor(None, sys.stdin.readline)
+        if not line:
+            break
+        msg = parse_command(line, seq)
+        if msg is None:
+            print("?")
+            continue
+        await ws.send(json.dumps(msg))
+
+
+async def main() -> None:
+    """Connect to the server and interact via text commands."""
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    uri = "ws://127.0.0.1:7777/ws"
+    seq = Seq()
+    hello = build_hello(seq.next())
+    async with websockets.connect(uri) as ws:  # type: ignore[arg-type]
+        await ws.send(json.dumps(hello))
+        welcome = json.loads(await ws.recv())
+        print(welcome)
+
+        recv_task = asyncio.create_task(_recv_loop(ws))
+        send_task = asyncio.create_task(_input_loop(ws, seq))
+        done, pending = await asyncio.wait(
+            [recv_task, send_task], return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 if __name__ == "__main__":

--- a/tests/test_client_commands.py
+++ b/tests/test_client_commands.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from client import net
+
+
+def _seq() -> net.Seq:
+    return net.Seq()
+
+
+def test_parse_add_node(monkeypatch) -> None:
+    monkeypatch.setattr(net, "_now_ms", lambda: 0)
+    msg = net.parse_command("add_node n1 source", _seq())
+    assert msg == {
+        "t": "edit_batch",
+        "seq": "1",
+        "ts": 0,
+        "edits": [
+            {"op": "add_node", "id": "n1", "type": "source", "params": {}}
+        ],
+    }
+
+
+def test_parse_set_param(monkeypatch) -> None:
+    monkeypatch.setattr(net, "_now_ms", lambda: 0)
+    msg = net.parse_command("set_param n1 target_pressure 101", _seq())
+    assert msg and msg["edits"][0]["value"] == 101
+    msg2 = net.parse_command("set_param n1 label hello", _seq())
+    assert msg2 and msg2["edits"][0]["value"] == "hello"
+
+
+def test_parse_control(monkeypatch) -> None:
+    monkeypatch.setattr(net, "_now_ms", lambda: 0)
+    seq = _seq()
+    assert net.parse_command("pause", seq) == {
+        "t": "control",
+        "seq": "1",
+        "ts": 0,
+        "pause": True,
+    }
+    rate_msg = net.parse_command("rate 40", seq)
+    assert rate_msg and rate_msg["tick_hz"] == 40
+
+
+def test_parse_save(monkeypatch) -> None:
+    monkeypatch.setattr(net, "_now_ms", lambda: 0)
+    msg = net.parse_command("save", _seq())
+    assert msg == {"t": "save", "seq": "1", "ts": 0}
+
+
+def test_parse_invalid() -> None:
+    assert net.parse_command("bogus", _seq()) is None
+

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,51 @@
+import asyncio
+import contextlib
+import json
+import sys
+from pathlib import Path
+
+import websockets  # type: ignore[import-not-found]
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server import net
+
+HELLO = {
+    "t": "hello",
+    "seq": "1",
+    "ts": 0,
+    "accept_major": [1],
+    "min_minor": 0,
+    "id_type": "string",
+    "accept_features": [],
+    "want_fields": ["node.p", "edge.q"],
+    "client_version": "0.0.0",
+}
+
+
+def test_save(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(net, "_now_ms", lambda: 0)
+
+    async def inner() -> None:
+        server, broadcaster = await net.start_server()
+        try:
+            async with websockets.connect("ws://127.0.0.1:7777/ws") as ws:
+                await ws.send(json.dumps(HELLO))
+                await ws.recv()  # welcome
+                await ws.recv()  # first snapshot
+                await ws.send(json.dumps({"t": "save", "seq": "2", "ts": 0}))
+                await asyncio.sleep(0.1)
+                path = tmp_path / "save-0.json"
+                assert path.exists()
+                data = json.loads(path.read_text())
+                assert "nodes" in data and "pipes" in data and "meta" in data
+        finally:
+            server.close()
+            await server.wait_closed()
+            broadcaster.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await broadcaster
+
+    asyncio.run(inner())
+


### PR DESCRIPTION
## Summary
- add text-mode client commands (node/pipe edits, param updates, control, save) with error printing
- support async save on server
- document quick start workflow and troubleshooting

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b25107ea94833397949b1f129d167e