### PR TITLE
feat: autoload pump-to-drain smoke level

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ Both server and client communicate on `ws://127.0.0.1:7777/ws` by default.
 python -m server.net
 ```
 
-The server listens on `ws://127.0.0.1:7777/ws` and broadcasts full snapshots at the configured tick rate (default 50 Hz).
+The server listens on `ws://127.0.0.1:7777/ws` and broadcasts full snapshots at
+the configured tick rate (default 50 Hz). On startup it auto-loads the level
+`level.smoke.pump_to_drain.v1`, a simple pump-to-drain scenario used for smoke
+testing.
 
 Start the console client in another terminal:
 

--- a/levels/level.smoke.pump_to_drain.v1.json
+++ b/levels/level.smoke.pump_to_drain.v1.json
@@ -1,0 +1,54 @@
+{
+  "level_id": "level.smoke.pump_to_drain.v1",
+  "size_m": { "w": 60, "h": 30 },
+  "ambient": { "fluid_id": "water", "temperature_C": 20.0 },
+  "nodes": [
+    {
+      "id": "P1",
+      "type": "pump",
+      "name": "Main Pump",
+      "pos": [10, 15],
+      "pump_curve": {
+        "max_head_bar": 1.2,
+        "Qmax_Ls": 1.80
+      },
+      "control": { "mode": "fixed_speed", "speed_pct": 100 }
+    },
+    {
+      "id": "D1",
+      "type": "drain",
+      "name": "Atmospheric Drain",
+      "pos": [50, 15],
+      "pressure_bar": 0.0
+    }
+  ],
+  "pipes": [
+    {
+      "id": "E_P1_D1",
+      "a": "P1",
+      "b": "D1",
+      "length_m": 30,
+      "diameter_mm": 150,
+      "max_pressure_bar": 6,
+      "resistance_bar_per_Ls": 0.50
+    }
+  ],
+  "ui_probes": [
+    { "id": "M_FLOW", "attach_to": "E_P1_D1", "mode": "flow_pressure" }
+  ],
+  "objectives": [
+    {
+      "id": "OBJ_STABLE",
+      "type": "sustain_band",
+      "target_edge": "E_P1_D1",
+      "metric": "flow_Ls",
+      "min": 0.50,
+      "max": 1.70,
+      "duration_s": 30
+    }
+  ],
+  "hints": [
+    "This is a minimal test: pump → pipe → drain.",
+    "Watch the flow and pressure probe to verify stability."
+  ]
+}

--- a/server/io.py
+++ b/server/io.py
@@ -1,1 +1,38 @@
 """Input/output utilities for the server."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any
+
+from .state import SimState
+
+
+def load_level(path: str | Path, sim: SimState) -> None:
+    """Load a level file into ``sim``.
+
+    The level schema is a JSON document containing ``nodes`` and ``pipes``
+    arrays. All extra fields on nodes and pipes are stored inside the
+    ``params`` mapping of :class:`SimState` entries so the simulation can
+    evolve without a fixed schema.
+    """
+    data: dict[str, Any] = json.loads(Path(path).read_text(encoding="utf-8"))
+    sim.nodes = {}
+    sim.pipes = {}
+    for node in data.get("nodes", []):
+        params = {k: v for k, v in node.items() if k not in {"id", "type"}}
+        sim.nodes[node["id"]] = {
+            "id": node["id"],
+            "type": node.get("type", "junction"),
+            "params": params,
+            "state": {"p": 0},
+        }
+    for pipe in data.get("pipes", []):
+        params = {k: v for k, v in pipe.items() if k not in {"id", "a", "b"}}
+        sim.pipes[pipe["id"]] = {
+            "id": pipe["id"],
+            "a": pipe["a"],
+            "b": pipe["b"],
+            "params": params,
+            "state": {"q": 0, "dir": 0},
+        }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -53,8 +53,8 @@ def test_snapshot_broadcast() -> None:
                 await asyncio.wait_for(ws.recv(), timeout=1)
                 snapshot = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
                 assert snapshot["t"] == "snapshot"
-                assert snapshot["nodes"] == []
-                assert snapshot["pipes"] == []
+                assert {n["id"] for n in snapshot["nodes"]} == {"P1", "D1"}
+                assert [p["id"] for p in snapshot["pipes"]] == ["E_P1_D1"]
                 assert snapshot["meta"] == {"solve_ms": 0}
         finally:
             server.close()


### PR DESCRIPTION
## Summary
- load a default pump-to-drain smoke test level on server startup
- provide level loader utility and JSON level definition
- document the smoke test level and adjust server snapshot test

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b25a64251c833382a585fd467d926b