### PR TITLE
Add server-client handshake integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,4 +179,8 @@ mypy .
 pytest -q
 ```
 
+The test suite includes an integration check that starts the server on the
+default port and verifies that a client can connect and receive broadcast
+snapshots.
+
 `mypy` may report that no Python files are present until code is added; this is expected in the seed.

--- a/tests/test_server_client_handshake.py
+++ b/tests/test_server_client_handshake.py
@@ -1,0 +1,31 @@
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+import sys
+
+import websockets  # type: ignore[import-not-found]
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from server import net as server_net
+from client import net as client_net
+
+
+def test_server_client_handshake() -> None:
+    async def inner() -> None:
+        server, broadcaster = await server_net.start_server()
+        try:
+            async with websockets.connect("ws://127.0.0.1:7777/ws") as ws:
+                await ws.send(json.dumps(client_net.build_hello()))
+                welcome = json.loads(await asyncio.wait_for(ws.recv(), timeout=1))
+                assert welcome["t"] == "welcome"
+                snapshot = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+                assert snapshot["t"] == "snapshot"
+        finally:
+            server.close()
+            await server.wait_closed()
+            broadcaster.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await broadcaster
+
+    asyncio.run(inner())


### PR DESCRIPTION
## Summary
- document new integration test for server-client communication
- add server-client handshake test to ensure broadcasts on default port

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b261a966348333aec6aea4a11852ed