### PR TITLE
Broadcast simulation state in snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ pszcz-server
 The server listens on `ws://127.0.0.1:7777/ws` and broadcasts full snapshots at
 the configured tick rate (default 50 Hz). On startup it auto-loads the level
 `level.smoke.pump_to_drain.v1`, a simple pump-to-drain scenario used for smoke
-testing.
+testing. Clients immediately receive the nodes and pipes from this level in the
+first snapshot.
 
 Start the console client in another terminal:
 

--- a/server/net.py
+++ b/server/net.py
@@ -177,12 +177,13 @@ async def _send_error(ws: WSProtocol, state: ServerState, code: str, message: st
 
 
 async def _broadcast_snapshots(state: ServerState) -> None:
-    """Broadcast minimal snapshots at the configured rate."""
+    """Broadcast snapshots of the current simulation state."""
     while True:
+        snap = state.sim.snapshot()
         payload = {
             "t": time.time(),
-            "nodes": [],
-            "pipes": [],
+            "nodes": snap["nodes"],
+            "pipes": snap["pipes"],
             "version": PROTOCOL_VERSION,
         }
         message = json.dumps(payload)


### PR DESCRIPTION
## Summary
- include SimState contents in broadcast snapshots
- document that initial level data is visible to clients

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2fd45af3483338c9192cd4d9a2321