### PR TITLE
Implement grid-based map with material types and water depth simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ about the running server. Example: `curl http://127.0.0.1:7778/health`.
 - **t0** – original interactive client now located under `client/t0`.
   Run with `python -m client.t0` or the `pszcz-client` wrapper.
 - **t1** – read-only terminal client with emoji or ASCII output.
+  It renders a grid of material tiles, each tracking its own water depth.
   Run with `python -m client.t1.emoji_client` (wrapper: `pszcz-client-start-t1`).
 
 The previous client entry points were replaced with `python -m client.t0`.

--- a/README_T1.md
+++ b/README_T1.md
@@ -25,13 +25,25 @@ Options:
 
 ## Map format
 
+Each map defines a 2D grid where every cell specifies the material and the
+current water depth:
+
 ```json
 {
-  "rows": 11,
-  "cols": 36,
-  "pump": {"row": 5, "col": 2},
-  "pipe": {"row": 5, "start_col": 3, "end_col": 33},
-  "sink": {"row": 5, "col": 34}
+  "rows": 2,
+  "cols": 3,
+  "grid": [
+    [
+      {"material": "hole", "depth": 0.0},
+      {"material": "brick", "depth": 0.0},
+      {"material": "hole", "depth": 1.0}
+    ],
+    [
+      {"material": "stone", "depth": 0.0},
+      {"material": "hole", "depth": 0.5},
+      {"material": "filter", "depth": 0.0}
+    ]
+  ]
 }
 ```
 

--- a/client/t1/model.py
+++ b/client/t1/model.py
@@ -1,25 +1,17 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List, Literal
+
+Material = Literal["brick", "stone", "hole", "filter", "gate"]
 
 
 @dataclass
-class Pump:
-    row: int
-    col: int
+class Pixel:
+    """Single map cell carrying material type and water depth."""
 
-
-@dataclass
-class Pipe:
-    row: int
-    start_col: int
-    end_col: int
-
-
-@dataclass
-class Sink:
-    row: int
-    col: int
+    material: Material
+    depth: float = 0.0
 
 
 @dataclass
@@ -34,14 +26,11 @@ class FlowSnapshot:
 class MapState:
     rows: int
     cols: int
-    pump: Pump
-    pipe: Pipe
-    sink: Sink
+    grid: List[List[Pixel]] = field(default_factory=list)
 
 
 def default_map(rows: int = 11, cols: int = 36) -> MapState:
-    mid = rows // 2
-    pump = Pump(mid, 2)
-    pipe = Pipe(mid, 3, cols - 3)
-    sink = Sink(mid, cols - 2)
-    return MapState(rows, cols, pump, pipe, sink)
+    grid: List[List[Pixel]] = [
+        [Pixel("hole", 0.0) for _ in range(cols)] for _ in range(rows)
+    ]
+    return MapState(rows, cols, grid)

--- a/client/t1/serialize.py
+++ b/client/t1/serialize.py
@@ -2,32 +2,37 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
-from .model import MapState, Pump, Pipe, Sink
+from .model import MapState, Pixel
 
 
-def export_map(state: MapState) -> dict:
+def export_map(state: MapState) -> dict[str, Any]:
     return {
         "rows": state.rows,
         "cols": state.cols,
-        "pump": {"row": state.pump.row, "col": state.pump.col},
-        "pipe": {
-            "row": state.pipe.row,
-            "start_col": state.pipe.start_col,
-            "end_col": state.pipe.end_col,
-        },
-        "sink": {"row": state.sink.row, "col": state.sink.col},
+        "grid": [
+            [{"material": p.material, "depth": p.depth} for p in row]
+            for row in state.grid
+        ],
     }
 
 
-def import_map(data: dict) -> MapState:
-    return MapState(
-        rows=data["rows"],
-        cols=data["cols"],
-        pump=Pump(**data["pump"]),
-        pipe=Pipe(**data["pipe"]),
-        sink=Sink(**data["sink"]),
-    )
+def import_map(data: dict[str, Any]) -> MapState:
+    rows = data["rows"]
+    cols = data["cols"]
+    grid_data = data.get("grid", [])
+    grid = [
+        [Pixel(cell.get("material", "hole"), float(cell.get("depth", 0.0))) for cell in row]
+        for row in grid_data
+    ]
+    # Ensure grid has correct size
+    if len(grid) < rows:
+        grid.extend([[Pixel("hole", 0.0) for _ in range(cols)] for _ in range(rows - len(grid))])
+    for row in grid:
+        if len(row) < cols:
+            row.extend([Pixel("hole", 0.0) for _ in range(cols - len(row))])
+    return MapState(rows, cols, grid)
 
 
 def save_map(state: MapState, path: str | Path) -> None:

--- a/client/t1/view.py
+++ b/client/t1/view.py
@@ -2,15 +2,20 @@ from __future__ import annotations
 
 from .model import FlowSnapshot, MapState
 
-
-def _pipe_char(flow: float, ascii: bool) -> str:
-    if ascii:
-        return "==" if flow >= 0.5 else "--"
-    if flow < 0.2:
-        return "▫️"
-    if flow < 0.6:
-        return "💧"
-    return "🌊"
+MATERIAL_EMOJI = {
+    "brick": "🧱",
+    "stone": "🪨",
+    "hole": "  ",
+    "filter": "🔳",
+    "gate": "🚪",
+}
+MATERIAL_ASCII = {
+    "brick": "[]",
+    "stone": "##",
+    "hole": "  ",
+    "filter": "FF",
+    "gate": "||",
+}
 
 
 def _bar(value: float, *, ascii: bool) -> str:
@@ -23,24 +28,18 @@ def _bar(value: float, *, ascii: bool) -> str:
 
 
 def render(state: MapState, snap: FlowSnapshot, *, ascii: bool = False, no_ansi: bool = False) -> str:
-    pump_tile = "P " if ascii else "🚰"
-    sink_tile = "S " if ascii else "🕳️"
-    empty_tile = "  " if ascii else " "
-    pipe_tile = _pipe_char(snap.flow_rate, ascii)
+    palette = MATERIAL_ASCII if ascii else MATERIAL_EMOJI
+    water_tile = "~~" if ascii else "💧"
 
     grid_lines: list[str] = []
-    for r in range(state.rows):
-        row: list[str] = []
-        for c in range(state.cols):
-            if r == state.pump.row and c == state.pump.col:
-                row.append(pump_tile)
-            elif r == state.sink.row and c == state.sink.col:
-                row.append(sink_tile)
-            elif r == state.pipe.row and state.pipe.start_col <= c <= state.pipe.end_col:
-                row.append(pipe_tile)
+    for row in state.grid:
+        rendered: list[str] = []
+        for cell in row:
+            if cell.depth > 0:
+                rendered.append(water_tile)
             else:
-                row.append(empty_tile)
-        grid_lines.append("".join(row))
+                rendered.append(palette.get(cell.material, "??"))
+        grid_lines.append("".join(rendered))
 
     alarm_line = ""
     if snap.alarm:

--- a/server/state.py
+++ b/server/state.py
@@ -6,17 +6,30 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
+class Pixel:
+    """Single cell in the simulation grid."""
+
+    material: str
+    depth: float = 0.0
+
+
+@dataclass
 class SimState:
-    """Simulation state consisting of nodes and pipes."""
+    """Simulation state consisting of nodes, pipes and a grid."""
 
     nodes: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     pipes: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    grid: List[List[Pixel]] = field(default_factory=list)
 
-    def snapshot(self) -> Dict[str, List[Dict[str, Any]]]:
-        """Return a snapshot of current nodes and pipes."""
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a snapshot of current nodes, pipes and grid."""
         return {
             "nodes": list(self.nodes.values()),
             "pipes": list(self.pipes.values()),
+            "grid": [
+                [{"material": cell.material, "depth": cell.depth} for cell in row]
+                for row in self.grid
+            ],
         }
 
     def apply_edits(self, edits: List[Dict[str, Any]]) -> Optional[Dict[str, str]]:

--- a/server/tick.py
+++ b/server/tick.py
@@ -1,1 +1,39 @@
-"""Tick loop for advancing the simulation."""
+from __future__ import annotations
+
+from .state import SimState
+
+SOLID = {"brick", "stone"}
+FILTER = {"filter"}
+
+
+def _is_open(material: str) -> bool:
+    return material not in SOLID
+
+
+def flow_step(state: SimState) -> None:
+    """Advance water simulation by one tick."""
+    rows = len(state.grid)
+    if rows == 0:
+        return
+    cols = len(state.grid[0])
+    new_depths = [[cell.depth for cell in row] for row in state.grid]
+    for r in range(rows - 1, -1, -1):
+        for c in range(cols):
+            cell = state.grid[r][c]
+            if cell.material in SOLID:
+                new_depths[r][c] = 0.0
+                continue
+            if cell.depth <= 0:
+                continue
+            below_r = r + 1
+            if below_r < rows:
+                below = state.grid[below_r][c]
+                if _is_open(below.material):
+                    transfer = cell.depth
+                    if cell.material in FILTER:
+                        transfer *= 0.5
+                    new_depths[r][c] -= transfer
+                    new_depths[below_r][c] += transfer
+    for r in range(rows):
+        for c in range(cols):
+            state.grid[r][c].depth = max(new_depths[r][c], 0.0)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from client.t1.model import default_map
+from client.t1.serialize import export_map, import_map
+from server.state import Pixel as SPixel, SimState
+from server.tick import flow_step
+
+
+def test_map_serialization_roundtrip() -> None:
+    state = default_map(2, 2)
+    state.grid[0][0].material = "hole"
+    state.grid[0][0].depth = 1.0
+    data = export_map(state)
+    loaded = import_map(data)
+    assert loaded.grid[0][0].material == "hole"
+    assert loaded.grid[0][0].depth == 1.0
+
+
+def test_water_flows_down() -> None:
+    sim = SimState()
+    sim.grid = [[SPixel("hole", 1.0)], [SPixel("hole", 0.0)]]
+    flow_step(sim)
+    assert sim.grid[0][0].depth == 0.0
+    assert sim.grid[1][0].depth == 1.0
+
+
+def test_filter_reduces_flow() -> None:
+    sim = SimState()
+    sim.grid = [[SPixel("filter", 1.0)], [SPixel("hole", 0.0)]]
+    flow_step(sim)
+    assert sim.grid[0][0].depth == 0.5
+    assert sim.grid[1][0].depth == 0.5


### PR DESCRIPTION
## Summary
- extend t1 MapState to a grid of material tiles with per-cell water depth
- support serializing and deserializing the grid in JSON maps
- simulate simple water flow on the server respecting material properties
- document new map format and add tests for grid manipulation

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3418f41908333b4fc5cb5a49d1b97