### PR TITLE
feat: color-coded rendering with legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ about the running server. Example: `curl http://127.0.0.1:7778/health`.
 - **t0** – original interactive client now located under `client/t0`.
   Run with `python -m client.t0` or the `pszcz-client` wrapper.
 - **t1** – read-only terminal client with emoji or ASCII output.
-  It renders a grid of material tiles, each tracking its own water depth.
+  It renders a colour-coded grid of material tiles with water depth and shows a
+  legend including the current resolution (default 1 cm per pixel).
   Run with `python -m client.t1.emoji_client` (wrapper: `pszcz-client-start-t1`).
 
 The previous client entry points were replaced with `python -m client.t0`.

--- a/README_T1.md
+++ b/README_T1.md
@@ -1,8 +1,9 @@
 # t1 Client
 
 `t1` is a read-only terminal client that renders a simple water flow using
-emoji (with an ASCII fallback). It does not accept any user input and
-terminates via `Ctrl+C`.
+emoji (with an ASCII fallback). Materials and water depth are colour coded and a
+legend with the current resolution is shown. It does not accept any user input
+and terminates via `Ctrl+C`.
 
 ## Usage
 
@@ -19,6 +20,7 @@ Options:
   connection fails the client falls back to the mock and shows an alarm.
 - `--ascii` – render using ASCII characters instead of emoji.
 - `--no-ansi` – disable ANSI escape codes (useful for snapshot tests).
+- `--cm-per-pixel` – physical size represented by one pixel (default 1.0 cm).
 - `--map path.json` – load a map from JSON.
 - `--save path.json` – export the current map to JSON.
 - `--fps 5` – set refresh rate (default 8).
@@ -26,12 +28,13 @@ Options:
 ## Map format
 
 Each map defines a 2D grid where every cell specifies the material and the
-current water depth:
+current water depth. The physical resolution `cm_per_pixel` defaults to 1.0:
 
 ```json
 {
   "rows": 2,
   "cols": 3,
+  "cm_per_pixel": 1.0,
   "grid": [
     [
       {"material": "hole", "depth": 0.0},

--- a/client/t1/emoji_client.py
+++ b/client/t1/emoji_client.py
@@ -15,6 +15,7 @@ def main() -> None:
     parser.add_argument("--rows", type=int, default=11)
     parser.add_argument("--cols", type=int, default=36)
     parser.add_argument("--fps", type=float, default=8.0)
+    parser.add_argument("--cm-per-pixel", type=float, default=1.0, help="resolution in cm per pixel")
     parser.add_argument("--ascii", action="store_true")
     parser.add_argument("--no-ansi", action="store_true")
     parser.add_argument("--map", type=str)
@@ -23,8 +24,9 @@ def main() -> None:
 
     if args.map:
         state = serialize.load_map(args.map)
+        state.cm_per_pixel = args.cm_per_pixel
     else:
-        state = model.default_map(args.rows, args.cols)
+        state = model.default_map(args.rows, args.cols, cm_per_pixel=args.cm_per_pixel)
 
     if args.save:
         serialize.save_map(state, args.save)

--- a/client/t1/model.py
+++ b/client/t1/model.py
@@ -27,10 +27,13 @@ class MapState:
     rows: int
     cols: int
     grid: List[List[Pixel]] = field(default_factory=list)
+    cm_per_pixel: float = 1.0
 
 
-def default_map(rows: int = 11, cols: int = 36) -> MapState:
+def default_map(
+    rows: int = 11, cols: int = 36, *, cm_per_pixel: float = 1.0
+) -> MapState:
     grid: List[List[Pixel]] = [
         [Pixel("hole", 0.0) for _ in range(cols)] for _ in range(rows)
     ]
-    return MapState(rows, cols, grid)
+    return MapState(rows, cols, grid, cm_per_pixel)

--- a/client/t1/serialize.py
+++ b/client/t1/serialize.py
@@ -11,6 +11,7 @@ def export_map(state: MapState) -> dict[str, Any]:
     return {
         "rows": state.rows,
         "cols": state.cols,
+        "cm_per_pixel": state.cm_per_pixel,
         "grid": [
             [{"material": p.material, "depth": p.depth} for p in row]
             for row in state.grid
@@ -21,6 +22,7 @@ def export_map(state: MapState) -> dict[str, Any]:
 def import_map(data: dict[str, Any]) -> MapState:
     rows = data["rows"]
     cols = data["cols"]
+    cm_per_pixel = float(data.get("cm_per_pixel", 1.0))
     grid_data = data.get("grid", [])
     grid = [
         [Pixel(cell.get("material", "hole"), float(cell.get("depth", 0.0))) for cell in row]
@@ -32,7 +34,7 @@ def import_map(data: dict[str, Any]) -> MapState:
     for row in grid:
         if len(row) < cols:
             row.extend([Pixel("hole", 0.0) for _ in range(cols - len(row))])
-    return MapState(rows, cols, grid)
+    return MapState(rows, cols, grid, cm_per_pixel)
 
 
 def save_map(state: MapState, path: str | Path) -> None:

--- a/client/t1/view.py
+++ b/client/t1/view.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
 from .model import FlowSnapshot, MapState
 
-MATERIAL_EMOJI = {
-    "brick": "🧱",
-    "stone": "🪨",
-    "hole": "  ",
-    "filter": "🔳",
-    "gate": "🚪",
+
+class MaterialSpec(TypedDict):
+    emoji: str
+    ascii: str
+    color: str | None
+
+
+MATERIALS: dict[str, MaterialSpec] = {
+    "brick": {"emoji": "🧱", "ascii": "[]", "color": "31"},
+    "stone": {"emoji": "🪨", "ascii": "##", "color": "37"},
+    "hole": {"emoji": "  ", "ascii": "  ", "color": None},
+    "filter": {"emoji": "🔳", "ascii": "FF", "color": "32"},
+    "gate": {"emoji": "🚪", "ascii": "||", "color": "33"},
 }
-MATERIAL_ASCII = {
-    "brick": "[]",
-    "stone": "##",
-    "hole": "  ",
-    "filter": "FF",
-    "gate": "||",
-}
+
+WATER_TILE = {"emoji": "💧", "ascii": "~~"}
+WATER_COLORS = ["34", "36", "94", "96"]
 
 
 def _bar(value: float, *, ascii: bool) -> str:
@@ -27,18 +32,30 @@ def _bar(value: float, *, ascii: bool) -> str:
     return full * filled + empty * (4 - filled)
 
 
+def _color(text: str, code: str | None, *, no_ansi: bool) -> str:
+    if no_ansi or not code:
+        return text
+    return f"\x1b[{code}m{text}\x1b[0m"
+
+
 def render(state: MapState, snap: FlowSnapshot, *, ascii: bool = False, no_ansi: bool = False) -> str:
-    palette = MATERIAL_ASCII if ascii else MATERIAL_EMOJI
-    water_tile = "~~" if ascii else "💧"
+    water_tile = WATER_TILE["ascii" if ascii else "emoji"]
 
     grid_lines: list[str] = []
     for row in state.grid:
         rendered: list[str] = []
         for cell in row:
             if cell.depth > 0:
-                rendered.append(water_tile)
+                idx = min(int(cell.depth * len(WATER_COLORS)), len(WATER_COLORS) - 1)
+                rendered.append(
+                    _color(water_tile, WATER_COLORS[idx], no_ansi=no_ansi)
+                )
             else:
-                rendered.append(palette.get(cell.material, "??"))
+                entry = MATERIALS.get(cell.material)
+                if entry is None:
+                    entry = {"emoji": "??", "ascii": "??", "color": None}
+                ch = entry["ascii" if ascii else "emoji"]
+                rendered.append(_color(ch, entry["color"], no_ansi=no_ansi))
         grid_lines.append("".join(rendered))
 
     alarm_line = ""
@@ -50,10 +67,25 @@ def render(state: MapState, snap: FlowSnapshot, *, ascii: bool = False, no_ansi:
         f"Flow {_bar(snap.flow_rate, ascii=ascii)} ({snap.flow_rate:.2f}) | "
         f"Sink {_bar(snap.pressure_sink, ascii=ascii)} ({snap.pressure_sink:.2f})"
     )
+    mode_line = f"Mode: {'ASCII' if ascii else 'Emoji'} | Res: {state.cm_per_pixel:.1f} cm/px"
+
+    legend_items = []
+    for name, entry in MATERIALS.items():
+        ch = entry["ascii" if ascii else "emoji"]
+        legend_items.append(f"{ch}={name}")
+    water_levels = []
+    for idx, code in enumerate(WATER_COLORS, 1):
+        level = int(idx / len(WATER_COLORS) * 100)
+        water_levels.append(
+            f"{_color(water_tile, code, no_ansi=no_ansi)}{level}%"
+        )
+    legend_line = "Legend: " + ", ".join(legend_items) + " | Water: " + " ".join(water_levels)
 
     lines = [alarm_line] if alarm_line else []
     lines.extend(grid_lines)
     lines.append(status)
+    lines.append(mode_line)
+    lines.append(legend_line)
     frame = "\n".join(lines)
     if not no_ansi:
         frame = "\x1b[2J\x1b[H" + frame

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -14,13 +14,15 @@ from server.tick import flow_step
 
 
 def test_map_serialization_roundtrip() -> None:
-    state = default_map(2, 2)
+    state = default_map(2, 2, cm_per_pixel=1.0)
     state.grid[0][0].material = "hole"
     state.grid[0][0].depth = 1.0
     data = export_map(state)
     loaded = import_map(data)
     assert loaded.grid[0][0].material == "hole"
     assert loaded.grid[0][0].depth == 1.0
+    assert data["cm_per_pixel"] == 1.0
+    assert loaded.cm_per_pixel == 1.0
 
 
 def test_water_flows_down() -> None:

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from client.t1.model import FlowSnapshot, MapState, Pixel
+from client.t1.view import render
+
+
+def _sample_state() -> MapState:
+    return MapState(
+        2,
+        2,
+        [
+            [Pixel("brick", 0.0), Pixel("hole", 0.5)],
+            [Pixel("filter", 0.0), Pixel("stone", 0.0)],
+        ],
+        1.0,
+    )
+
+
+def _sample_snap() -> FlowSnapshot:
+    return FlowSnapshot(0.0, 0.0, 0.0)
+
+
+def test_render_no_ansi_snapshot() -> None:
+    state = _sample_state()
+    snap = _sample_snap()
+    frame = render(state, snap, ascii=False, no_ansi=True)
+    expected = (
+        "🧱💧\n"
+        "🔳🪨\n"
+        "Source ▱▱▱▱ (0.00) | Flow ▱▱▱▱ (0.00) | Sink ▱▱▱▱ (0.00)\n"
+        "Mode: Emoji | Res: 1.0 cm/px\n"
+        "Legend: 🧱=brick, 🪨=stone,   =hole, 🔳=filter, 🚪=gate | Water: 💧25% 💧50% 💧75% 💧100%"
+    )
+    assert frame == expected
+    assert "\x1b" not in frame
+
+
+def test_render_ascii_fallback_snapshot() -> None:
+    state = _sample_state()
+    snap = _sample_snap()
+    frame = render(state, snap, ascii=True, no_ansi=True)
+    expected = (
+        "[]~~\n"
+        "FF##\n"
+        "Source ░░░░ (0.00) | Flow ░░░░ (0.00) | Sink ░░░░ (0.00)\n"
+        "Mode: ASCII | Res: 1.0 cm/px\n"
+        "Legend: []=brick, ##=stone,   =hole, FF=filter, ||=gate | Water: ~~25% ~~50% ~~75% ~~100%"
+    )
+    assert frame == expected
+    assert "\x1b" not in frame
+


### PR DESCRIPTION
## Summary
- render full grid with material/water color mapping and legend
- expose `cm_per_pixel` resolution and CLI option
- add tests for ASCII fallback and no-ANSI snapshots

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3438dc7088333b5b8d77b9941bf7b