### PR TITLE
Document pixel grid and update protocol

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -117,7 +117,7 @@ Both fields are optional; server applies only provided keys.
 
 ### 3.5 `snapshot` (server → clients)
 
-**MVP uses full snapshots** only. Fields included are agreed in handshake (`fields`). Minimal payload has pressures on nodes and flows on edges.
+**MVP uses full snapshots** only. Fields included are agreed in handshake (`fields`). Minimal payload has pressures on nodes and flows on edges. A pixel grid describing terrain and water depth may be included via the `grid` field.
 
 ```json
 {
@@ -131,6 +131,19 @@ Both fields are optional; server applies only provided keys.
   "pipes": [
     { "id":"e501", "a":"n123", "b":"n200", "params":{ "...": "..." }, "state": { "q": 0.18, "dir": 1 } }
   ],
+  "grid": {
+    "cm_per_pixel": 1.0,
+    "cells": [
+      [
+        {"material": "hole", "depth": 0.0},
+        {"material": "brick", "depth": 0.0}
+      ],
+      [
+        {"material": "hole", "depth": 0.5},
+        {"material": "filter", "depth": 0.0}
+      ]
+    ]
+  },
   "meta": { "solve_ms": 2.3 }
 }
 ```
@@ -188,6 +201,12 @@ Server performs an **async** save and may log the file path (MVP: no reply is re
 - **Params (MVP):** `{ "length": number, "diameter": number, "roughness": number, "open": number }`
 - **State (MVP):** `{ "q": number, "dir": -1|0|1 }`
 
+### 4.3 Grid Cell
+
+- **Required:** `material (string)`, `depth (number)`
+- **Materials:** `"brick"`, `"stone"`, `"hole"`, `"filter"`, `"gate"`
+- **Depth:** `0.0–1.0` fraction of the cell filled with water
+
 ## 5) Units & Conventions (stable in major 1)
 
 - Pressure `p`: **Pa**.  
@@ -210,6 +229,10 @@ Server performs an **async** save and may log the file path (MVP: no reply is re
   "use_features": [],
   "nodes": [ ... ],
   "pipes": [ ... ],
+  "grid": {
+    "cm_per_pixel": 1.0,
+    "cells": [ [ {"material": "hole", "depth": 0.0} ] ]
+  },
   "meta": { "note": "optional free text" }
 }
 ```

--- a/README_T1.md
+++ b/README_T1.md
@@ -5,6 +5,28 @@ emoji (with an ASCII fallback). Materials and water depth are colour coded and a
 legend with the current resolution is shown. It does not accept any user input
 and terminates via `Ctrl+C`.
 
+## Pixel grid
+
+The simulation is represented as a rectangular grid of pixels. Each **pixel**
+stores a `material` and the current water `depth`:
+
+| Material | Emoji | Description |
+| --- | --- | --- |
+| `brick` | 🧱 | solid wall blocking the flow |
+| `stone` | 🪨 | immovable obstacle |
+| `hole` | _(empty)_ | free space where water may flow |
+| `filter` | 🔳 | porous block that slows water |
+| `gate` | 🚪 | controllable gate |
+
+The optional `--cm-per-pixel` parameter defines the physical size represented
+by one grid cell (default **1.0 cm**).
+
+### Water depth
+
+Water `depth` is a floating‑point value in the **0.0–1.0** range and indicates
+how much of the cell is filled with water. The renderer maps the value to four
+blue shades (25 % steps). Values above 1.0 are clamped to the darkest shade.
+
 ## Usage
 
 ```sh
@@ -50,8 +72,46 @@ current water depth. The physical resolution `cm_per_pixel` defaults to 1.0:
 }
 ```
 
-## Limitations
+### Example: mixed materials
 
-- Emoji width varies between terminals; the client assumes two-column
-  emoji which may not hold everywhere.
-- Each frame redraws the entire screen.
+```json
+{
+  "rows": 3,
+  "cols": 4,
+  "cm_per_pixel": 0.5,
+  "grid": [
+    [
+      {"material": "stone", "depth": 0.0},
+      {"material": "filter", "depth": 0.0},
+      {"material": "gate", "depth": 0.0},
+      {"material": "hole", "depth": 0.0}
+    ],
+    [
+      {"material": "hole", "depth": 0.0},
+      {"material": "hole", "depth": 0.5},
+      {"material": "hole", "depth": 1.0},
+      {"material": "brick", "depth": 0.0}
+    ],
+    [
+      {"material": "brick", "depth": 0.0},
+      {"material": "brick", "depth": 0.0},
+      {"material": "brick", "depth": 0.0},
+      {"material": "brick", "depth": 0.0}
+    ]
+  ]
+}
+```
+
+## Colour & Emoji Interface
+
+By default the client renders the grid using coloured emoji. An ASCII
+fallback can be enabled with `--ascii`.
+
+*Screenshot omitted because binary files are not stored in this repository.*
+
+### Limitations
+
+- Emoji width varies between terminals; the client assumes two-column emoji
+  which may not hold everywhere.
+- Each frame redraws the entire screen which can impact performance on slow
+  terminals.

--- a/client/t1/emoji_client.py
+++ b/client/t1/emoji_client.py
@@ -1,3 +1,9 @@
+"""Command-line client rendering the pixel grid using emoji or ASCII.
+
+Supports optional WebSocket connection, map import/export and configurable
+physical resolution via ``--cm-per-pixel``.
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/client/t1/model.py
+++ b/client/t1/model.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Model objects shared by the :mod:`client.t1` renderer.
+
+`MapState` holds a pixel grid. Each :class:`Pixel` stores the terrain
+`material` and current water `depth` where ``0.0`` means dry and ``1.0``
+represents a completely filled cell.
+"""
+
 from dataclasses import dataclass, field
 from typing import List, Literal
 
@@ -8,7 +15,15 @@ Material = Literal["brick", "stone", "hole", "filter", "gate"]
 
 @dataclass
 class Pixel:
-    """Single map cell carrying material type and water depth."""
+    """Single map cell carrying material type and water depth.
+
+    Parameters
+    ----------
+    material:
+        One of ``"brick"``, ``"stone"``, ``"hole"``, ``"filter"`` or ``"gate"``.
+    depth:
+        Fraction ``0.0–1.0`` describing how full the cell is with water.
+    """
 
     material: Material
     depth: float = 0.0
@@ -24,6 +39,8 @@ class FlowSnapshot:
 
 @dataclass
 class MapState:
+    """Grid dimensions and pixel data for the simulation map."""
+
     rows: int
     cols: int
     grid: List[List[Pixel]] = field(default_factory=list)

--- a/client/t1/serialize.py
+++ b/client/t1/serialize.py
@@ -1,3 +1,9 @@
+"""JSON import/export helpers for :class:`~client.t1.model.MapState`.
+
+The file format stores `rows`, `cols`, global `cm_per_pixel` and a `grid`
+array of pixels with `material` and `depth` fields.
+"""
+
 from __future__ import annotations
 
 import json

--- a/server/net.py
+++ b/server/net.py
@@ -1,4 +1,8 @@
-"""Minimal WebSocket server for the PSZCZ Flow Simulator."""
+"""Minimal WebSocket server for the PSZCZ Flow Simulator.
+
+Broadcast snapshots include a pixel grid describing terrain materials and
+water depth.
+"""
 
 from __future__ import annotations
 
@@ -145,6 +149,7 @@ async def _write_save(state: ServerState, note: str) -> None:
         "tick": state.tick,
         "nodes": snap["nodes"],
         "pipes": snap["pipes"],
+        "grid": {"cm_per_pixel": 1.0, "cells": snap["grid"]},
         "meta": {"note": note},
     }
     path = Path(f"save-{_now_ms()}.json")
@@ -184,6 +189,7 @@ async def _broadcast_snapshots(state: ServerState) -> None:
             "t": time.time(),
             "nodes": snap["nodes"],
             "pipes": snap["pipes"],
+            "grid": {"cm_per_pixel": 1.0, "cells": snap["grid"]},
             "version": PROTOCOL_VERSION,
         }
         message = json.dumps(payload)

--- a/server/state.py
+++ b/server/state.py
@@ -1,4 +1,9 @@
-"""In-memory simulation state and edit application logic."""
+"""In-memory simulation state and edit application logic.
+
+The simulator maintains a pixel grid alongside node and pipe structures. Each
+grid cell stores a terrain ``material`` and water ``depth`` in the ``0.0–1.0``
+range.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -7,7 +12,15 @@ from typing import Any, Dict, List, Optional
 
 @dataclass
 class Pixel:
-    """Single cell in the simulation grid."""
+    """Single cell in the simulation grid.
+
+    Attributes
+    ----------
+    material:
+        One of ``brick``, ``stone``, ``hole``, ``filter`` or ``gate``.
+    depth:
+        Fraction ``0.0–1.0`` describing how full the cell is with water.
+    """
 
     material: str
     depth: float = 0.0
@@ -15,7 +28,7 @@ class Pixel:
 
 @dataclass
 class SimState:
-    """Simulation state consisting of nodes, pipes and a grid."""
+    """Simulation state consisting of nodes, pipes and a pixel grid."""
 
     nodes: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     pipes: Dict[str, Dict[str, Any]] = field(default_factory=dict)

--- a/tests/test_ws_roundtrip.py
+++ b/tests/test_ws_roundtrip.py
@@ -35,6 +35,7 @@ async def test_ws_roundtrip() -> None:
             assert welcome["t"] == "welcome"
             snapshot = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
             assert "nodes" in snapshot
+            assert "grid" in snapshot and "cells" in snapshot["grid"]
             edits = [
                 {"op": "add_node", "id": "n1", "type": "source", "params": {}},
                 {"op": "add_node", "id": "n2", "type": "sink", "params": {}},


### PR DESCRIPTION
## Summary
- document pixel-based map with materials, water depth, and emoji interface (screenshot omitted due to binary file limits)
- extend protocol to carry grid data and define grid cell entity
- include grid in server snapshots and saves

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3451f1d2c8333a5a57d1c43686d01