### PR TITLE
Default t1 client to mock with preset parameters

### DIFF
--- a/README_T1.md
+++ b/README_T1.md
@@ -30,14 +30,13 @@ blue shades (25 % steps). Values above 1.0 are clamped to the darkest shade.
 ## Usage
 
 ```sh
-python -m client.t1.emoji_client --mock --seed 123 --rate 0.8 \
-  --rows 11 --cols 36 --fps 8
+python -m client.t1.emoji_client
 ```
 
 Options:
 
-- `--mock` – force the deterministic mock adapter (default).
-- `--seed` / `--rate` – parameters for the mock adapter.
+- `--mock` / `--no-mock` – use the deterministic mock adapter (default).
+- `--seed` / `--rate` – parameters for the mock adapter (defaults 123 and 0.8).
 - `--endpoint ws://host:port/ws` – try to use a socket adapter; if the
   connection fails the client falls back to the mock and shows an alarm.
 - `--ascii` – render using ASCII characters instead of emoji.

--- a/client/t1/emoji_client.py
+++ b/client/t1/emoji_client.py
@@ -14,9 +14,14 @@ from . import adapter, model, serialize, view
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="t1 emoji client")
-    parser.add_argument("--mock", action="store_true", help="force mock adapter")
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--rate", type=float, default=0.5)
+    parser.add_argument(
+        "--mock",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="use mock adapter (default)",
+    )
+    parser.add_argument("--seed", type=int, default=123, help="PRNG seed")
+    parser.add_argument("--rate", type=float, default=0.8, help="mock event rate")
     parser.add_argument("--endpoint", type=str)
     parser.add_argument("--rows", type=int, default=11)
     parser.add_argument("--cols", type=int, default=36)

--- a/install_pszcz.sh
+++ b/install_pszcz.sh
@@ -7,6 +7,7 @@ INSTALL_ROOT="${INSTALL_ROOT:-/opt/pszcz}"
 REPO_DIR="${REPO_DIR:-$INSTALL_ROOT/repo}"
 SERVER_ENTRY="${SERVER_ENTRY:-server/net.py}"   # lze změnit např. na "server/app.py" nebo "python -m server.net"
 CLIENT_ENTRY="${CLIENT_ENTRY:-python -m client.t0}"
+CLIENT_T1_ENTRY="${CLIENT_T1_ENTRY:-python -m client.t1.emoji_client}"
 PY_MIN_MAJOR=3
 PY_MIN_MINOR=10
 
@@ -111,7 +112,7 @@ BASH
 # Start/stop skripty (bez systemd)
 make_runner "/usr/local/bin/pszcz-server-start" "$INSTALL_ROOT/server/venv" "$SERVER_ENTRY" "$REPO_DIR"
 make_runner "/usr/local/bin/pszcz-client-start" "$INSTALL_ROOT/client/venv" "$CLIENT_ENTRY" "$REPO_DIR"
-make_runner "/usr/local/bin/pszcz-client-start-t1" "$INSTALL_ROOT/client/venv" "python -m client.t1.emoji_client" "$REPO_DIR"
+make_runner "/usr/local/bin/pszcz-client-start-t1" "$INSTALL_ROOT/client/venv" "$CLIENT_T1_ENTRY" "$REPO_DIR"
 
 cat >/usr/local/bin/pszcz-server-stop <<'BASH'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- default t1 client to mock mode with seed 123 and rate 0.8
- document simple t1 invocation and options
- allow install script to configure t1 entry point

## Testing
- `python -m client.t1.emoji_client --ascii --no-ansi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b347891d1483339386ffdcebcc6ea9