### PR TITLE
Simplify protocol for pixel grid

### DIFF
--- a/DIRECTIONS_FOR_CODEX.md
+++ b/DIRECTIONS_FOR_CODEX.md
@@ -14,16 +14,16 @@ Create these runnable components **without adding new files beyond this list** u
 
 - `server/` (Python 3.11+)
   - Headless WS server at `ws://127.0.0.1:7777/ws`.
-  - In-memory state (dicts or simple classes) for nodes/pipes.
+  - In-memory state (dicts or simple classes) for a pixel grid (materials and depths).
   - Tick loop with configurable `tick_hz` (default 50).
-  - Apply `edit_batch`, `control`, `save`.
+  - Apply `edit_grid`, `control`, `save`.
   - Broadcast **full `snapshot`** to all clients at steady cadence.
   - Async save of a **full JSON** snapshot (schema as in `PROTOCOL.md`).
 
 - `client/` (Python)
   - Connects to WS and performs `hello`/`welcome`.
-  - Receives and validates `snapshot` against requested `fields`.
-  - Minimal, text-based or very simple UI to add nodes/pipes, set params, pause/resume, change tick rate, and request save.
+  - Receives and validates `snapshot` (grid only).
+  - Minimal, text-based or very simple UI to edit pixels, pause/resume, change tick rate, and request save.
   - Renders something minimal (ASCII/very basic 2D). A later PR will switch to Pygame or Godot; do not block on graphics now.
 
 - `scripts/` (optional, later)
@@ -37,11 +37,11 @@ Create these runnable components **without adding new files beyond this list** u
    - Unknown fields are ignored gracefully.
 
 2. **Edits**
-   - Client can send `edit_batch` with: add_node, add_pipe, set_param, del.
-   - Server validates collisions and returns `error` with `code:"id_conflict"` if duplicate ID is proposed.
+   - Client can send `edit_grid` with `set_pixel` operations.
+   - Server validates material names and bounds; invalid requests return `error` with `code:"invalid_material"` or `"index_out_of_bounds"`.
 
 3. **Ticking & Snapshots**
-   - Server ticks at ~50 Hz with minimal jitter; broadcasts **full** snapshots at ≥20 Hz by default.
+   - Server ticks at ~50 Hz with minimal jitter; broadcasts **full** grid snapshots at ≥20 Hz by default.
    - `meta.solve_ms` included (even if it’s just elapsed step time).
 
 4. **Save (no pause)**
@@ -67,8 +67,8 @@ Create these runnable components **without adding new files beyond this list** u
 ## 4) Tests (MVP)
 
 - Unit tests (pytest) for:
-  - Handshake negotiation: `accept_major`, `min_minor`, `fields`.
-  - `edit_batch` validation (duplicate IDs, unknown ops).
+  - Handshake negotiation: `accept_major`, `min_minor`.
+  - `edit_grid` validation (invalid material, out-of-range coordinates).
   - Snapshot schema sanity (required fields present; units untouched).
   - Save file round-trip (write → read basic fields).
 - No integration tests with graphics yet.
@@ -95,4 +95,4 @@ Create these runnable components **without adding new files beyond this list** u
 - Lint/type checks pass.
 - README updated with run instructions.
 - Protocol examples in `PROTOCOL.md` remain valid.
-- No breaking changes to existing message fields; version remains `1.0` for MVP.
+- No breaking changes to existing message fields; version remains `2.0` for MVP.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,39 +1,35 @@
-# PSZCZ Wire Protocol — Version 1.0
+# PSZCZ Wire Protocol — Version 2.0
 
-This file defines the **stable wire contract** between clients and servers. It focuses on **compatibility**, **extensibility**, and **clarity**. MVP uses **JSON over WebSocket**.
+This file defines the **stable wire contract** between clients and servers. It focuses on **compatibility**, **extensibility**,
+and **clarity**. Communication uses **JSON over WebSocket**.
 
 ## 1) Versioning & Compatibility
 
 - `version = { major, minor }`
-- **Major**: breaking changes only (type/meaning changes).
-- **Minor**: strictly **additive** (new fields/messages/enums). No removal or type change of existing fields.
+- **Major**: breaking changes only.
+- **Minor**: strictly **additive**.
 
-### 1.1 Handshake & Feature Negotiation
+### 1.1 Handshake
 
 Client → Server `hello` **must** include:
-- `accept_major: [1]` — list of acceptable majors (MVP includes `1`).
-- `min_minor: 0` — lowest minor the client supports within major 1.
-- `id_type: "string"` — clients send IDs as strings.
-- `accept_features: []` — e.g., later `["delta-1","ack-ids-1","zstd-1"]`.
-- `want_fields: ["node.p","edge.q"]` — data fields requested in snapshots.
+- `accept_major: [2]` — list of acceptable majors (MVP includes `2`).
+- `min_minor: 0` — lowest minor the client supports within major 2.
 - `client_version: "x.y.z"` — freeform.
 
 Server → Client `welcome` includes:
-- `version: { major:1, minor:K }`
-- `schema_rev: "1.K"`
-- `fields: [...]` (subset the server will actually send)
-- `use_features: [...]` (intersection of `accept_features` and server support)
+- `version: { major:2, minor:K }`
+- `schema_rev: "2.K"`
 - `tick_hz: number`
 - `server_version: "x.y.z"`
 
 If no common **major**, server sends `error { code:"incompatible_version" }` and closes.
 
-### 1.2 Extensibility Rules (Major-1 Contract)
+### 1.2 Extensibility Rules (Major-2 Contract)
 
 - **Add only**: add new fields/messages/enums; never change existing types or semantics.
 - **Ignore unknowns**: both sides must ignore unknown fields and unknown message types.
 - **Do not remove** fields within the same major (they may be deprecated and not sent unless requested).
-- **Stable units**: Pa, m³/s, m. A unit change requires a new **major**.
+- **Stable units**: depth is measured in metres. A unit change requires a new **major**.
 
 ## 2) Envelope & Common Fields
 
@@ -54,12 +50,9 @@ Unknown `t` values must be ignored safely.
   "t": "hello",
   "seq": "1",
   "ts": 0,
-  "accept_major": [1],
+  "accept_major": [2],
   "min_minor": 0,
-  "id_type": "string",
-  "accept_features": [],
-  "want_fields": ["node.p", "edge.q"],
-  "client_version": "0.1.0"
+  "client_version": "0.2.0"
 }
 ```
 
@@ -70,36 +63,31 @@ Unknown `t` values must be ignored safely.
   "t": "welcome",
   "seq": "2",
   "ts": 0,
-  "version": { "major": 1, "minor": 0 },
-  "schema_rev": "1.0",
-  "fields": ["node.p", "edge.q"],
-  "use_features": [],
+  "version": { "major": 2, "minor": 0 },
+  "schema_rev": "2.0",
   "tick_hz": 50,
-  "server_version": "0.1.0"
+  "server_version": "0.2.0"
 }
 ```
 
-### 3.3 `edit_batch` (client → server)
+### 3.3 `edit_grid` (client → server)
 
-Applies a set of edits atomically. In MVP the **client chooses IDs** (strings). Server rejects collisions via `error`.
+Applies pixel edits atomically. Each operation is:
 
-Each `edit` is one of:
+- `{ "op": "set_pixel", "r": 0, "c": 1, "material": "stone", "depth": 0.0 }`
 
-- `{"op":"add_node","id":"n123","type":"pump","params":{...}}`
-- `{"op":"add_pipe","id":"e501","a":"n123","b":"n200","params":{...}}`
-- `{"op":"set_param","id":"n123","key":"open","value":0.5}`
-- `{"op":"del","id":"e501"}`
+`depth` is optional and defaults to `0.0`.
 
 ```json
 {
-  "t": "edit_batch",
+  "t": "edit_grid",
   "seq": "10",
   "ts": 0,
-  "edits": [ /* array of edits as above */ ]
+  "ops": [
+    { "op": "set_pixel", "r": 0, "c": 1, "material": "spring", "depth": 0.0 }
+  ]
 }
 ```
-
-> Future: feature `ack-ids-1` adds `temp_id` → `id` mapping acknowledgement.
 
 ### 3.4 `control` (client → server)
 
@@ -117,7 +105,7 @@ Both fields are optional; server applies only provided keys.
 
 ### 3.5 `snapshot` (server → clients)
 
-**MVP uses full snapshots** only. Fields included are agreed in handshake (`fields`). Minimal payload has pressures on nodes and flows on edges. A pixel grid describing terrain and water depth may be included via the `grid` field.
+**MVP uses full snapshots** only, containing just the pixel grid.
 
 ```json
 {
@@ -125,30 +113,18 @@ Both fields are optional; server applies only provided keys.
   "seq": "100",
   "ts": 0,
   "tick": 12345,
-  "nodes": [
-    { "id":"n123", "type":"pump", "params":{ "...": "..." }, "state": { "p": 102300 } }
-  ],
-  "pipes": [
-    { "id":"e501", "a":"n123", "b":"n200", "params":{ "...": "..." }, "state": { "q": 0.18, "dir": 1 } }
-  ],
   "grid": {
     "cm_per_pixel": 1.0,
     "cells": [
-      [
-        {"material": "hole", "depth": 0.0},
-        {"material": "brick", "depth": 0.0}
-      ],
-      [
-        {"material": "hole", "depth": 0.5},
-        {"material": "filter", "depth": 0.0}
-      ]
+      [ { "material": "space", "depth": 0.0 }, { "material": "stone", "depth": 0.0 } ],
+      [ { "material": "spring", "depth": 0.5 }, { "material": "sink", "depth": 0.0 } ]
     ]
   },
   "meta": { "solve_ms": 2.3 }
 }
 ```
 
-> Future: with `delta-1`, server may send only changed entities plus a periodic full.
+> Future: with `delta-1`, server may send only changed cells plus a periodic full.
 
 ### 3.6 `save` (client → server)
 
@@ -170,84 +146,57 @@ Server performs an **async** save and may log the file path (MVP: no reply is re
   "t": "error",
   "seq": "x",
   "ts": 0,
-  "code": "id_conflict",
-  "message": "Entity id already exists"
+  "code": "invalid_material",
+  "message": "Material not recognised"
 }
 ```
 
-**Stable error codes** (strings):  
-`"incompatible_version"`, `"feature_not_enabled"`, `"bad_request"`, `"id_conflict"`, `"unknown_entity"`, `"unauthorized"`
+**Stable error codes** (strings): `"incompatible_version"`, `"feature_not_enabled"`, `"bad_request"`, `"invalid_material"`, `"index_out_of_bounds"`, `"unauthorized"`
 
-## 4) Entities: Required & Optional Fields
-
-### 4.1 Node
-
-- **Required:** `id (string)`, `type (string)`, `params (object)`, `state (object)`
-- **Node types (MVP):** `"source"`, `"sink"`, `"junction"`, `"pump"`, `"valve"`, `"accumulator"`
-- **State (MVP):** `p` (pressure, Pa)
-- **Params (examples, not exhaustive):**
-  - `source`: `{ "target_pressure": number }`
-  - `sink`: `{ "target_flow": number }`
-  - `pump`: `{ "rpm": number }`
-  - `valve`: `{ "open": number }` (0..1)
-  - `accumulator`: `{ "capacitance": number }`
-  - `junction`: `{}`
-
-> Params/state are **maps** so new keys can be added later without breaking compatibility.
-
-### 4.2 Pipe
-
-- **Required:** `id (string)`, `a (string)`, `b (string)`, `params (object)`, `state (object)`
-- **Params (MVP):** `{ "length": number, "diameter": number, "roughness": number, "open": number }`
-- **State (MVP):** `{ "q": number, "dir": -1|0|1 }`
-
-### 4.3 Grid Cell
+## 4) Grid Cells
 
 - **Required:** `material (string)`, `depth (number)`
-- **Materials:** `"brick"`, `"stone"`, `"hole"`, `"filter"`, `"gate"`
+- **Materials:**
+  - `stone` — impenetrable.
+  - `space` — empty traversable cell.
+  - `spring` — source of water.
+  - `sink` — drains water.
 - **Depth:** `0.0–1.0` fraction of the cell filled with water
 
-## 5) Units & Conventions (stable in major 1)
+## 5) Units & Conventions (stable in major 2)
 
-- Pressure `p`: **Pa**.  
-- Flow `q`: **m^3/s**.  
-- Length/diameter: **m**.  
+- Water depth: **m**.
 - Time fields (`ts`): ms since Unix epoch.
 
 ## 6) Saves (MVP)
 
-**File format:** one JSON object (UTF-8).  
+**File format:** one JSON object (UTF-8).
 **Required top-level fields:**
 
 ```json
 {
-  "version": { "major": 1, "minor": 0 },
-  "schema_rev": "1.0",
+  "version": { "major": 2, "minor": 0 },
+  "schema_rev": "2.0",
   "ts": 0,
   "tick": 12345,
-  "fields": ["node.p","edge.q"],
-  "use_features": [],
-  "nodes": [ ... ],
-  "pipes": [ ... ],
   "grid": {
     "cm_per_pixel": 1.0,
-    "cells": [ [ {"material": "hole", "depth": 0.0} ] ]
+    "cells": [ [ {"material": "space", "depth": 0.0} ] ]
   },
   "meta": { "note": "optional free text" }
 }
 ```
 
-Clients/servers must ignore unknown fields when loading.  
+Clients/servers must ignore unknown fields when loading.
 Loading a different **major** is not allowed.
 
 ## 7) Control-Lock & Multi-Client
 
 - Multiple clients may subscribe to snapshots.
-- Exactly **one controlling client** is allowed to send edits/controls (MVP can hard-code this to “first client wins” or a simple toggle admin command).
+- Exactly **one controlling client** is allowed to send edits/controls (MVP can hard-code this to "first client wins" or a simple toggle admin command).
 - Future: authenticated roles and server-side arbitration.
 
 ## 8) Feature Flags (reserved names)
 
 - `"delta-1"` — delta snapshots (periodic full + changes).
-- `"ack-ids-1"` — server acknowledges client-proposed IDs and may remap.
 - `"zstd-1"` — message compression.


### PR DESCRIPTION
## Summary
- replace node/pipe messaging with pixel grid protocol
- introduce `stone`, `space`, `spring`, and `sink` materials
- add `edit_grid` message and grid-only snapshots

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37fc83a388333b7ef671ab9953b66