### PR TITLE
docs: switch to pixel grid paradigm

### DIFF
--- a/DIRECTIONS_FOR_CODEX.md
+++ b/DIRECTIONS_FOR_CODEX.md
@@ -75,7 +75,7 @@ Create these runnable components **without adding new files beyond this list** u
 
 ## 5) Performance Targets (MVP—not strict)
 
-- With placeholder physics, a graph of ~5k edges should tick at 50 Hz on a mainstream desktop CPU.
+- With placeholder physics, a grid of ~5k pixels should tick at 50 Hz on a mainstream desktop CPU.
 - Memory use is not constrained in MVP (the future server may use far more RAM and advanced solvers).
 
 ## 6) Roadmap Tasks (post-MVP; open issues)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # PSZCZ Flow Simulator — Seed (MVP)
 
 Protocol-first, CPU-only **client–server** simulator for a 2D grid-based fluid game.
+The entire world is a uniform pixel grid without any graph constructs.
 This repository is a **seed**: minimal files, **complete specification**. All code will be generated later by Codex based solely on what’s here.
 
 - **Server (authoritative):** headless, Linux-friendly, computes physics. For MVP: trivial placeholder physics; later: real hydraulics.
@@ -15,7 +16,7 @@ This repository is a **seed**: minimal files, **complete specification**. All co
 1. Run a minimal server that:
    - Accepts WS connections.
   - Maintains an in-memory grid of pixel **materials** and water depths.
-  - Applies **`edit_grid`** operations from a single controlling client.
+  - Applies **`edit_grid`** messages composed of `set_pixel` operations from a single controlling client.
   - Emits **full grid snapshots** at a steady tick (e.g., 20–50 Hz).
   - Writes **async full saves** on request.
 
@@ -41,6 +42,7 @@ This repository is a **seed**: minimal files, **complete specification**. All co
 - **Authoritative state lives on the server.**  
   Client and server each maintain a local copy; server is the truth source.
 - **Networking:** One WS endpoint `/ws`. JSON messages. Multiple clients can connect; exactly **one has control** (control-lock).
+- **State:** All simulation data is stored in a 2D pixel array; there are no graph structures.
 - **Ticking:** Server ticks at `tick_hz` (default 50). Snapshots broadcast at the same or a lower rate (default 20). Client interpolates if needed.
 
 
@@ -101,6 +103,10 @@ pip install .
 python -m server.net --host 0.0.0.0 --port 7777 --health-port 7778 --tick-hz 40 &
 curl http://127.0.0.1:7778/health
 python -m client.t1.emoji_client --endpoint ws://127.0.0.1:7777/ws
+
+# Example edit: turn cell (0,0) into a spring
+# (use any WS client to send the JSON line below)
+{"t":"edit_grid","seq":"1","ts":0,"ops":[{"op":"set_pixel","r":0,"c":0,"material":"spring"}]}
 ```
 
 The server writes `save-*.json` in its working directory.

--- a/README_T1.md
+++ b/README_T1.md
@@ -12,11 +12,10 @@ stores a `material` and the current water `depth`:
 
 | Material | Emoji | Description |
 | --- | --- | --- |
-| `brick` | 🧱 | solid wall blocking the flow |
-| `stone` | 🪨 | immovable obstacle |
-| `hole` | _(empty)_ | free space where water may flow |
-| `filter` | 🔳 | porous block that slows water |
-| `gate` | 🚪 | controllable gate |
+| `stone` | 🪨 | solid wall blocking the flow |
+| `space` | _(empty)_ | free space where water may flow |
+| `spring` | 💧 | source emitting water |
+| `sink` | 🕳️ | drain removing water |
 
 The optional `--cm-per-pixel` parameter defines the physical size represented
 by one grid cell (default **1.0 cm**).
@@ -48,15 +47,15 @@ Options:
 
 ## Default map
 
-Without `--map` the client loads an 8×8 demo level. The outer border is built
-from bricks while the centre row forms an open channel. The second cell of the
-channel starts filled with water acting as a source and the far end represents
-the sink.
+Without `--map` the client loads an 8×8 demo level. The outer border uses
+`stone` pixels while the centre row forms an open channel of `space`. The
+second cell of the channel is a `spring` and the far end is a `sink`.
 
 ## Map format
 
 Each map defines a 2D grid where every cell specifies the material and the
-current water depth. The physical resolution `cm_per_pixel` defaults to 1.0:
+current water depth. Only `stone`, `space`, `spring` and `sink` are valid
+materials. The physical resolution `cm_per_pixel` defaults to 1.0:
 
 ```json
 {
@@ -65,14 +64,14 @@ current water depth. The physical resolution `cm_per_pixel` defaults to 1.0:
   "cm_per_pixel": 1.0,
   "grid": [
     [
-      {"material": "hole", "depth": 0.0},
-      {"material": "brick", "depth": 0.0},
-      {"material": "hole", "depth": 1.0}
+      {"material": "space", "depth": 0.0},
+      {"material": "stone", "depth": 0.0},
+      {"material": "spring", "depth": 1.0}
     ],
     [
       {"material": "stone", "depth": 0.0},
-      {"material": "hole", "depth": 0.5},
-      {"material": "filter", "depth": 0.0}
+      {"material": "space", "depth": 0.5},
+      {"material": "sink", "depth": 0.0}
     ]
   ]
 }
@@ -88,21 +87,21 @@ current water depth. The physical resolution `cm_per_pixel` defaults to 1.0:
   "grid": [
     [
       {"material": "stone", "depth": 0.0},
-      {"material": "filter", "depth": 0.0},
-      {"material": "gate", "depth": 0.0},
-      {"material": "hole", "depth": 0.0}
+      {"material": "spring", "depth": 0.0},
+      {"material": "space", "depth": 0.0},
+      {"material": "space", "depth": 0.0}
     ],
     [
-      {"material": "hole", "depth": 0.0},
-      {"material": "hole", "depth": 0.5},
-      {"material": "hole", "depth": 1.0},
-      {"material": "brick", "depth": 0.0}
+      {"material": "space", "depth": 0.0},
+      {"material": "space", "depth": 0.5},
+      {"material": "space", "depth": 1.0},
+      {"material": "stone", "depth": 0.0}
     ],
     [
-      {"material": "brick", "depth": 0.0},
-      {"material": "brick", "depth": 0.0},
-      {"material": "brick", "depth": 0.0},
-      {"material": "brick", "depth": 0.0}
+      {"material": "sink", "depth": 0.0},
+      {"material": "stone", "depth": 0.0},
+      {"material": "stone", "depth": 0.0},
+      {"material": "stone", "depth": 0.0}
     ]
   ]
 }


### PR DESCRIPTION
## Summary
- Rephrase project docs to focus on pixel-grid simulation and set_pixel edits
- Refresh t1 client docs with new pixel types and sample maps
- Drop lingering graph wording in developer directions

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b380f1bc3c8333995efb02d78a2e64