### PR TITLE
Simplify simulation state and expand materials

### DIFF
--- a/client/net.py
+++ b/client/net.py
@@ -1,19 +1,30 @@
-"""Thin wrapper exposing the interactive t0 client as ``client.net``.
-
-The underlying client already supports a ``--url`` flag to target a custom
-WebSocket endpoint.
-"""
+"""Minimal client helpers for protocol handshakes."""
 
 from __future__ import annotations
 
+import time
+from typing import Any, Dict
+
 from client.t0 import net as _t0_net
 
-build_hello = _t0_net.build_hello
+
+def build_hello(seq: str = "1") -> Dict[str, Any]:
+    """Return a hello message following :mod:`PROTOCOL`."""
+
+    return {
+        "t": "hello",
+        "seq": seq,
+        "ts": int(time.time() * 1000),
+        "accept_major": [2],
+        "min_minor": 0,
+        "client_version": "0.2.0",
+    }
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover - thin wrapper
     _t0_net.main()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()
+

--- a/client/t1/model.py
+++ b/client/t1/model.py
@@ -1,16 +1,11 @@
-"""Model objects shared by the :mod:`client.t1` renderer.
-
-`MapState` holds a pixel grid. Each :class:`Pixel` stores the terrain
-`material` and current water `depth` where ``0.0`` means dry and ``1.0``
-represents a completely filled cell.
-"""
+"""Model objects shared by the :mod:`client.t1` renderer."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import List, Literal
 
-Material = Literal["brick", "stone", "hole", "filter", "gate"]
+Material = Literal["stone", "space", "spring", "sink"]
 
 
 @dataclass
@@ -20,7 +15,7 @@ class Pixel:
     Parameters
     ----------
     material:
-        One of ``"brick"``, ``"stone"``, ``"hole"``, ``"filter"`` or ``"gate"``.
+        One of ``"stone"``, ``"space"``, ``"spring"`` or ``"sink"``.
     depth:
         Fraction ``0.0–1.0`` describing how full the cell is with water.
     """
@@ -52,9 +47,9 @@ def default_map(
 ) -> MapState:
     """Create a simple map with a horizontal channel and boundary walls.
 
-    The outer rim is filled with bricks while the middle row forms an open
-    channel. The second cell of the channel contains water to act as the
-    source. Other sizes fall back to the same pattern.
+    The outer rim is filled with ``stone`` while the middle row forms an open
+    channel of ``space``. The second cell of the channel is a ``spring`` and the
+    far end contains a ``sink``.
     """
 
     grid: List[List[Pixel]] = []
@@ -62,15 +57,17 @@ def default_map(
         row: List[Pixel] = []
         for c in range(cols):
             if r in (0, rows - 1) or c in (0, cols - 1):
-                row.append(Pixel("brick", 0.0))
+                row.append(Pixel("stone", 0.0))
             else:
-                row.append(Pixel("hole", 0.0))
+                row.append(Pixel("space", 0.0))
         grid.append(row)
 
     if rows > 2 and cols > 2:
         mid = rows // 2
         for c in range(1, cols - 1):
-            grid[mid][c] = Pixel("hole", 0.0)
-        grid[mid][1].depth = 1.0  # source cell
+            grid[mid][c] = Pixel("space", 0.0)
+        grid[mid][1] = Pixel("spring", 1.0)
+        grid[mid][cols - 2] = Pixel("sink", 0.0)
 
     return MapState(rows, cols, grid, cm_per_pixel)
+

--- a/client/t1/serialize.py
+++ b/client/t1/serialize.py
@@ -31,15 +31,15 @@ def import_map(data: dict[str, Any]) -> MapState:
     cm_per_pixel = float(data.get("cm_per_pixel", 1.0))
     grid_data = data.get("grid", [])
     grid = [
-        [Pixel(cell.get("material", "hole"), float(cell.get("depth", 0.0))) for cell in row]
+        [Pixel(cell.get("material", "space"), float(cell.get("depth", 0.0))) for cell in row]
         for row in grid_data
     ]
     # Ensure grid has correct size
     if len(grid) < rows:
-        grid.extend([[Pixel("hole", 0.0) for _ in range(cols)] for _ in range(rows - len(grid))])
+        grid.extend([[Pixel("space", 0.0) for _ in range(cols)] for _ in range(rows - len(grid))])
     for row in grid:
         if len(row) < cols:
-            row.extend([Pixel("hole", 0.0) for _ in range(cols - len(row))])
+            row.extend([Pixel("space", 0.0) for _ in range(cols - len(row))])
     return MapState(rows, cols, grid, cm_per_pixel)
 
 

--- a/client/t1/view.py
+++ b/client/t1/view.py
@@ -12,11 +12,10 @@ class MaterialSpec(TypedDict):
 
 
 MATERIALS: dict[str, MaterialSpec] = {
-    "brick": {"emoji": "🧱", "ascii": "[]", "color": "31"},
     "stone": {"emoji": "🪨", "ascii": "##", "color": "37"},
-    "hole": {"emoji": "  ", "ascii": "  ", "color": None},
-    "filter": {"emoji": "🔳", "ascii": "FF", "color": "32"},
-    "gate": {"emoji": "🚪", "ascii": "||", "color": "33"},
+    "space": {"emoji": "  ", "ascii": "  ", "color": None},
+    "spring": {"emoji": "💧", "ascii": "SS", "color": "34"},
+    "sink": {"emoji": "🕳️", "ascii": "OO", "color": "30"},
 }
 
 WATER_TILE = {"emoji": "💧", "ascii": "~~"}
@@ -90,3 +89,4 @@ def render(state: MapState, snap: FlowSnapshot, *, ascii: bool = False, no_ansi:
     if not no_ansi:
         frame = "\x1b[2J\x1b[H" + frame
     return frame
+

--- a/server/tick.py
+++ b/server/tick.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from .state import SimState
 
-SOLID = {"brick", "stone"}
-FILTER = {"filter"}
+
+SOLID = {"stone"}
 
 
 def _is_open(material: str) -> bool:
@@ -12,10 +12,20 @@ def _is_open(material: str) -> bool:
 
 def flow_step(state: SimState) -> None:
     """Advance water simulation by one tick."""
+
     rows = len(state.grid)
     if rows == 0:
         return
     cols = len(state.grid[0])
+
+    # Springs produce water, sinks remove it before each step.
+    for row in state.grid:
+        for cell in row:
+            if cell.material == "spring":
+                cell.depth = 1.0
+            elif cell.material == "sink":
+                cell.depth = 0.0
+
     new_depths = [[cell.depth for cell in row] for row in state.grid]
     for r in range(rows - 1, -1, -1):
         for c in range(cols):
@@ -30,10 +40,15 @@ def flow_step(state: SimState) -> None:
                 below = state.grid[below_r][c]
                 if _is_open(below.material):
                     transfer = cell.depth
-                    if cell.material in FILTER:
-                        transfer *= 0.5
                     new_depths[r][c] -= transfer
                     new_depths[below_r][c] += transfer
+
     for r in range(rows):
         for c in range(cols):
-            state.grid[r][c].depth = max(new_depths[r][c], 0.0)
+            cell = state.grid[r][c]
+            cell.depth = max(min(new_depths[r][c], 1.0), 0.0)
+            if cell.material == "spring":
+                cell.depth = 1.0
+            elif cell.material == "sink":
+                cell.depth = 0.0
+

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 import sys
 from pathlib import Path
 
@@ -15,11 +13,11 @@ from server.tick import flow_step
 
 def test_map_serialization_roundtrip() -> None:
     state = default_map(2, 2, cm_per_pixel=1.0)
-    state.grid[0][0].material = "hole"
+    state.grid[0][0].material = "space"
     state.grid[0][0].depth = 1.0
     data = export_map(state)
     loaded = import_map(data)
-    assert loaded.grid[0][0].material == "hole"
+    assert loaded.grid[0][0].material == "space"
     assert loaded.grid[0][0].depth == 1.0
     assert data["cm_per_pixel"] == 1.0
     assert loaded.cm_per_pixel == 1.0
@@ -27,15 +25,16 @@ def test_map_serialization_roundtrip() -> None:
 
 def test_water_flows_down() -> None:
     sim = SimState()
-    sim.grid = [[SPixel("hole", 1.0)], [SPixel("hole", 0.0)]]
+    sim.grid = [[SPixel("space", 1.0)], [SPixel("space", 0.0)]]
     flow_step(sim)
     assert sim.grid[0][0].depth == 0.0
     assert sim.grid[1][0].depth == 1.0
 
 
-def test_filter_reduces_flow() -> None:
+def test_spring_and_sink_behaviour() -> None:
     sim = SimState()
-    sim.grid = [[SPixel("filter", 1.0)], [SPixel("hole", 0.0)]]
+    sim.grid = [[SPixel("spring", 0.0)], [SPixel("sink", 0.5)]]
     flow_step(sim)
-    assert sim.grid[0][0].depth == 0.5
-    assert sim.grid[1][0].depth == 0.5
+    assert sim.grid[0][0].depth == 1.0  # spring refills
+    assert sim.grid[1][0].depth == 0.0  # sink drains
+

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -14,8 +14,8 @@ def _sample_state() -> MapState:
         2,
         2,
         [
-            [Pixel("brick", 0.0), Pixel("hole", 0.5)],
-            [Pixel("filter", 0.0), Pixel("stone", 0.0)],
+            [Pixel("stone", 0.0), Pixel("spring", 0.0)],
+            [Pixel("space", 0.5), Pixel("sink", 0.0)],
         ],
         1.0,
     )
@@ -30,11 +30,11 @@ def test_render_no_ansi_snapshot() -> None:
     snap = _sample_snap()
     frame = render(state, snap, ascii=False, no_ansi=True)
     expected = (
-        "🧱💧\n"
-        "🔳🪨\n"
+        "🪨💧\n"
+        "💧🕳️\n"
         "Source ▱▱▱▱ (0.00) | Flow ▱▱▱▱ (0.00) | Sink ▱▱▱▱ (0.00)\n"
         "Mode: Emoji | Res: 1.0 cm/px\n"
-        "Legend: 🧱=brick, 🪨=stone,   =hole, 🔳=filter, 🚪=gate | Water: 💧25% 💧50% 💧75% 💧100%"
+        "Legend: 🪨=stone,   =space, 💧=spring, 🕳️=sink | Water: 💧25% 💧50% 💧75% 💧100%"
     )
     assert frame == expected
     assert "\x1b" not in frame
@@ -45,11 +45,11 @@ def test_render_ascii_fallback_snapshot() -> None:
     snap = _sample_snap()
     frame = render(state, snap, ascii=True, no_ansi=True)
     expected = (
-        "[]~~\n"
-        "FF##\n"
+        "##SS\n"
+        "~~OO\n"
         "Source ░░░░ (0.00) | Flow ░░░░ (0.00) | Sink ░░░░ (0.00)\n"
         "Mode: ASCII | Res: 1.0 cm/px\n"
-        "Legend: []=brick, ##=stone,   =hole, FF=filter, ||=gate | Water: ~~25% ~~50% ~~75% ~~100%"
+        "Legend: ##=stone,   =space, SS=spring, OO=sink | Water: ~~25% ~~50% ~~75% ~~100%"
     )
     assert frame == expected
     assert "\x1b" not in frame

--- a/tests/test_ws_roundtrip.py
+++ b/tests/test_ws_roundtrip.py
@@ -34,14 +34,9 @@ async def test_ws_roundtrip() -> None:
             welcome = json.loads(await asyncio.wait_for(ws.recv(), timeout=1))
             assert welcome["t"] == "welcome"
             snapshot = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
-            assert "nodes" in snapshot
             assert "grid" in snapshot and "cells" in snapshot["grid"]
-            edits = [
-                {"op": "add_node", "id": "n1", "type": "source", "params": {}},
-                {"op": "add_node", "id": "n2", "type": "sink", "params": {}},
-                {"op": "add_pipe", "id": "p1", "a": "n1", "b": "n2", "params": {}},
-            ]
-            await ws.send(json.dumps({"t": "edit_batch", "seq": "2", "ts": 0, "edits": edits}))
+            ops = [{"op": "set_pixel", "r": 0, "c": 0, "material": "spring"}]
+            await ws.send(json.dumps({"t": "edit_grid", "seq": "2", "ts": 0, "ops": ops}))
             errors = []
             end = asyncio.get_running_loop().time() + 0.5
             while asyncio.get_running_loop().time() < end:
@@ -55,3 +50,4 @@ async def test_ws_roundtrip() -> None:
             assert not errors
     finally:
         await _stop(server, broadcaster, health)
+


### PR DESCRIPTION
## Summary
- refactor state to store only a pixel grid
- add new materials (stone, space, spring, sink) across client and server
- implement grid edit operations and update networking protocol

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3826831008333aba50657b9f7e4a9