### PR TITLE
feat: add new level JSON format and IO helpers

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -169,14 +169,15 @@ Server performs an **async** save and may log the file path (MVP: no reply is re
 
 ## 6) Saves (MVP)
 
-**File format:** one JSON object (UTF-8) containing only the grid and optional metadata.
+**File format:** one JSON object (UTF-8) containing grid dimensions and pixel
+data with optional metadata.
 
 ```json
 {
-  "grid": {
-    "cm_per_pixel": 1.0,
-    "cells": [ [ {"material": "space", "depth": 0.0} ] ]
-  },
+  "rows": 1,
+  "cols": 1,
+  "cm_per_pixel": 1.0,
+  "grid": [ [ { "material": "space", "depth": 0.0 } ] ],
   "meta": { "note": "optional free text" }
 }
 ```

--- a/levels/level.sample.v1.json
+++ b/levels/level.sample.v1.json
@@ -1,13 +1,10 @@
 {
-  "level_id": "level.sample.v1",
-  "grid": {
-    "cm_per_pixel": 1.0,
-    "cells": [
-      [ { "material": "spring", "depth": 0.0 }, { "material": "space", "depth": 0.0 } ],
-      [ { "material": "sink", "depth": 0.0 }, { "material": "space", "depth": 0.0 } ]
-    ]
-  },
-  "hints": [
-    "This is a minimal test grid."
+  "rows": 2,
+  "cols": 2,
+  "cm_per_pixel": 1.0,
+  "grid": [
+    [ { "material": "spring", "depth": 0.0 }, { "material": "space", "depth": 0.0 } ],
+    [ { "material": "sink", "depth": 0.0 }, { "material": "space", "depth": 0.0 } ]
   ]
 }
+

--- a/server/io.py
+++ b/server/io.py
@@ -12,22 +12,46 @@ from .state import Pixel, SimState
 def load_level(path: str | Path, sim: SimState) -> None:
     """Load a level file into ``sim``.
 
-    The level schema is a JSON document containing a ``grid`` object with a
-    ``cells`` array describing the pixel materials and water depths. Unknown
-    fields are ignored to allow forward compatibility.
+    The level schema is a JSON document containing only ``rows``, ``cols``,
+    ``cm_per_pixel`` and a two-dimensional ``grid`` array. Each grid cell
+    stores ``material`` and ``depth`` fields. Unknown fields are ignored to
+    allow forward compatibility.
     """
 
     data: dict[str, Any] = json.loads(Path(path).read_text(encoding="utf-8"))
-    grid = data.get("grid")
-    if isinstance(grid, dict):
-        cells = grid.get("cells")
-    else:
-        cells = grid
+    grid_data = data.get("grid") or data.get("pixels")
+    if not isinstance(grid_data, list):
+        grid_data = []
     sim.grid = [
         [
             Pixel(str(cell.get("material", "space")), float(cell.get("depth", 0.0)))
             for cell in row
         ]
-        for row in cells or []
+        for row in grid_data
     ]
+
+
+def save_level(
+    path: str | Path,
+    sim: SimState,
+    *,
+    cm_per_pixel: float = 1.0,
+    meta: dict[str, Any] | None = None,
+) -> None:
+    """Export ``sim`` to ``path`` using the level JSON format."""
+
+    rows = len(sim.grid)
+    cols = len(sim.grid[0]) if rows else 0
+    data: dict[str, Any] = {
+        "rows": rows,
+        "cols": cols,
+        "cm_per_pixel": cm_per_pixel,
+        "grid": [
+            [{"material": cell.material, "depth": cell.depth} for cell in row]
+            for row in sim.grid
+        ],
+    }
+    if meta:
+        data["meta"] = meta
+    Path(path).write_text(json.dumps(data), encoding="utf-8")
 

--- a/server/net.py
+++ b/server/net.py
@@ -15,7 +15,7 @@ import websockets  # type: ignore[import-not-found]
 from aiohttp import web
 
 from . import __version__
-from .io import load_level
+from .io import load_level, save_level
 from .state import Pixel, SimState
 
 
@@ -156,13 +156,9 @@ def _apply_control(msg: Dict[str, Any], control: ControlParams) -> None:
 async def _write_save(state: ServerState, note: str) -> None:
     """Write a full snapshot to ``save-<ts>.json`` asynchronously."""
 
-    snap = state.sim.snapshot()
-    data = {
-        "grid": {"cm_per_pixel": 1.0, "cells": snap["grid"]},
-        "meta": {"note": note} if note else {},
-    }
+    meta = {"note": note} if note else None
     path = Path(f"save-{_now_ms()}.json")
-    await asyncio.to_thread(path.write_text, json.dumps(data), encoding="utf-8")
+    await asyncio.to_thread(save_level, path, state.sim, meta=meta)
     logger.info("wrote %s", path)
 
 

--- a/tests/test_server_io.py
+++ b/tests/test_server_io.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from server.io import load_level, save_level
+from server.state import Pixel, SimState
+
+
+def test_save_and_load_level(tmp_path: Path) -> None:
+    sim = SimState()
+    sim.grid = [
+        [Pixel("space", 0.0), Pixel("stone", 0.0)],
+        [Pixel("spring", 0.5), Pixel("sink", 0.0)],
+    ]
+    path = tmp_path / "level.json"
+    save_level(path, sim, cm_per_pixel=1.0, meta={"note": "test"})
+
+    data = json.loads(path.read_text())
+    assert data["rows"] == 2
+    assert data["cols"] == 2
+    assert data["cm_per_pixel"] == 1.0
+    assert data["grid"][1][0]["material"] == "spring"
+
+    loaded = SimState()
+    load_level(path, loaded)
+    assert loaded.grid[1][0].material == "spring"
+    assert loaded.grid[1][0].depth == 0.5


### PR DESCRIPTION
## Summary
- define level files with rows, cols, cm_per_pixel and pixel grid
- add `load_level`/`save_level` helpers and use them for saves
- convert sample level and docs to the new format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44b36676883338bb5aede19ba22b8