### PR TITLE
feat: extend t0 client for pixel materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ about the running server. Example: `curl http://127.0.0.1:7778/health`.
 ## Clients
 
 - **t0** – original interactive client (deprecated).
+  It understands simple text commands such as:
+  - `set_pixel r c material [depth]` – change cell material and optional water level
+  - `set_depth r c value` – adjust water depth while keeping the current material
+  - `pause` / `resume`, `rate HZ`, `save`
 - **t1** – read-only terminal client with emoji or ASCII output.
   It renders a colour-coded grid of material tiles with water depth and shows a
   legend including the current resolution (default 1 cm per pixel).

--- a/client/t0/state.py
+++ b/client/t0/state.py
@@ -1,1 +1,34 @@
-"""Client-side simulation state."""
+"""Client-side simulation state helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class ClientState:
+    """Minimal holder for the most recent grid snapshot.
+
+    The interactive ``t0`` client keeps a copy of the server's grid so that
+    commands such as ``set_depth`` can reuse the existing material when only the
+    water level changes.
+    """
+
+    grid: List[List[Dict[str, Any]]] = field(default_factory=list)
+
+    def update(self, snapshot: Dict[str, Any]) -> None:
+        """Update state from a ``snapshot`` message."""
+
+        grid = snapshot.get("grid", {}).get("cells", [])
+        if isinstance(grid, list):
+            self.grid = grid
+
+    def material_at(self, r: int, c: int) -> str:
+        """Return material at ``r``, ``c`` or ``space`` if unknown."""
+
+        try:
+            return self.grid[r][c]["material"]
+        except Exception:  # pragma: no cover - out-of-bounds or malformed data
+            return "space"
+

--- a/tests/test_client_t0_net.py
+++ b/tests/test_client_t0_net.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from client.t0.net import Seq, parse_command
+from client.t0.state import ClientState
+
+
+def test_parse_set_pixel() -> None:
+    seq = Seq()
+    state = ClientState()
+    msg = parse_command("set_pixel 1 2 stone 0.5", seq, state)
+    assert msg is not None
+    assert msg["t"] == "edit_grid"
+    assert msg["ops"] == [
+        {"op": "set_pixel", "r": 1, "c": 2, "material": "stone", "depth": 0.5}
+    ]
+
+
+def test_parse_set_depth_uses_state() -> None:
+    seq = Seq()
+    state = ClientState()
+    state.update({"grid": {"cells": [[{"material": "spring", "depth": 0.0}]]}})
+    msg = parse_command("set_depth 0 0 0.3", seq, state)
+    assert msg is not None
+    assert msg["ops"] == [
+        {"op": "set_pixel", "r": 0, "c": 0, "material": "spring", "depth": 0.3}
+    ]
+


### PR DESCRIPTION
## Summary
- allow interactive client to edit pixel materials and water depth
- track latest grid snapshot for depth-only edits
- document t0 text commands and add unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b44d30e3e08333bd296b5e7523dffb